### PR TITLE
なぜか、本番環境だと動かない問題が発生。

### DIFF
--- a/server/template.yaml
+++ b/server/template.yaml
@@ -8,6 +8,7 @@ Description: >
 Globals:
   Function:
     Timeout: 60
+    MemorySize: 128
   Api:
     Cors:
       AllowOrigin: "'*'"


### PR DESCRIPTION
本番環境だと銘柄一覧取得APIが200ステータスコードを返すが、ボディが空になる問題が発生している。
ローカル開発環境だと正しく動作することを確認済み。
