### PR TITLE
Revert

### DIFF
--- a/server/src/work.ts
+++ b/server/src/work.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 export const work_stock_prices_importer_to_dynamodb_handler = async (): Promise<void> => {
-  console.log('work_stock_prices_importer_to_dynamodb_handler');
 }

--- a/server/src/work.ts
+++ b/server/src/work.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
 
-export const work_stock_prices_importer_to_dynamodb_handler = async (): Promise<void> => {
-  console.log('work_stock_prices_importer_to_dynamodb_handler')
+export const stock_prices_importer_handler = async (): Promise<void> => {
+  console.log('stock_prices_importer_handler')
 }

--- a/server/src/work.ts
+++ b/server/src/work.ts
@@ -1,4 +1,0 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
-
-export const work_stock_prices_importer_to_dynamodb_handler = async (): Promise<void> => {
-}

--- a/server/src/work.ts
+++ b/server/src/work.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
 
-export const stock_prices_importer_handler = async (): Promise<void> => {
-  console.log('stock_prices_importer_handler')
+export const work_stock_prices_importer_to_dynamodb_handler = async (): Promise<void> => {
+  console.log('work_stock_prices_importer_to_dynamodb_handler')
 }

--- a/server/src/work.ts
+++ b/server/src/work.ts
@@ -1,5 +1,5 @@
-/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/no-empty-function */
 
 export const work_stock_prices_importer_to_dynamodb_handler = async (): Promise<void> => {
-  console.log('work_stock_prices_importer_to_dynamodb_handler')
+  console.log('work_stock_prices_importer_to_dynamodb_handler');
 }

--- a/server/template.yaml
+++ b/server/template.yaml
@@ -182,21 +182,6 @@ Resources:
       DockerContext: ./src
       Dockerfile: Dockerfile
 
-  WorkStockPricesImporterToDynamoDBFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: !Sub ${AWS::StackName}-work-stock-prices-importer-to-dynamodb
-      PackageType: Image
-      ImageConfig:
-        Command: [ "work.work_stock_prices_importer_to_dynamodb_handler" ]
-      Role: !GetAtt MyLambdaRole.Arn
-      Architectures:
-      - x86_64
-    Metadata:
-      DockerTag: nodejs18.x-v1
-      DockerContext: ./src
-      Dockerfile: Dockerfile
-
   TechnicalGrowthRateFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/server/template.yaml
+++ b/server/template.yaml
@@ -192,8 +192,6 @@ Resources:
       Role: !GetAtt MyLambdaRole.Arn
       Architectures:
       - x86_64
-      MemorySize: 2048
-      Timeout: 900
     Metadata:
       DockerTag: nodejs18.x-v1
       DockerContext: ./src

--- a/server/template.yaml
+++ b/server/template.yaml
@@ -185,10 +185,10 @@ Resources:
   WorkStockPricesImporterToDynamoDBFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub ${AWS::StackName}-work-stock-prices-importer-to-dynamodb
+      FunctionName: !Sub ${AWS::StackName}-stock-prices-importer
       PackageType: Image
       ImageConfig:
-        Command: [ "work.work_stock_prices_importer_to_dynamodb_handler" ]
+        Command: [ "work.stock_prices_importer_handler" ]
       Role: !GetAtt MyLambdaRole.Arn
       Architectures:
       - x86_64

--- a/server/template.yaml
+++ b/server/template.yaml
@@ -185,10 +185,10 @@ Resources:
   WorkStockPricesImporterToDynamoDBFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub ${AWS::StackName}-stock-prices-importer
+      FunctionName: !Sub ${AWS::StackName}-work-stock-prices-importer-to-dynamodb
       PackageType: Image
       ImageConfig:
-        Command: [ "work.stock_prices_importer_handler" ]
+        Command: [ "work.work_stock_prices_importer_to_dynamodb_handler" ]
       Role: !GetAtt MyLambdaRole.Arn
       Architectures:
       - x86_64


### PR DESCRIPTION

これは取り消し、、、

S3からのCSVインポートで対応する。
既存のテーブルに対してインポートできないため、既存のテーブルを削除して、S3インポート際の新規作成時に同一名のテーブルを指定して、CloudFormationの管理下に入れなおす。
